### PR TITLE
fix: unwrap data in document_types.get(), rename schema_ → jsonSchema, add is_public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-07
+
+### Fixed
+
+- `client.document_types.get(id)` now correctly unwraps the `{ data }` envelope returned by `GET /api/document-types/{id}`. Previously every typed field (`id`, `name`, `codeType`, …) silently fell back to defaults because the actual fields were nested under `data`. Sync and async, including the `.with_raw_response.get()` variants. (Port of [docutray-node#20](https://github.com/docutray/docutray-node/pull/20).)
+
+### Changed
+
+- **Type-only breaking change:** renamed `DocumentType.schema_` to `DocumentType.jsonSchema` to match the API wire format. The previous name never received a value (the API returns `jsonSchema`), so no real consumer was reading the old attribute. Pre-1.0 patch releases are allowed to carry type-level breaking changes per project policy.
+
+### Added
+
+- `is_public: bool | None` keyword argument on `client.document_types.create()` and `client.document_types.update()` (sync, async, and raw response wrappers). Closes a gap from the [docutray-node#18](https://github.com/docutray/docutray-node/pull/18) port — the Node `DocumentTypeCreateParams` / `DocumentTypeUpdateParams` interfaces have always exposed `isPublic`.
+
 ## [0.2.0] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ page = client.document_types.list(search="invoice")
 
 # Get a specific document type
 doc_type = client.document_types.get("dt_invoice")
-print(f"Schema: {doc_type.schema_}")
+print(f"Schema: {doc_type.jsonSchema}")
 
 # Create a custom document type
 doc_type = client.document_types.create(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "docutray"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python library for the DocuTray API"
 readme = "README.md"
 license = "MIT"

--- a/src/docutray/_response.py
+++ b/src/docutray/_response.py
@@ -801,7 +801,7 @@ class DocumentTypesWithRawResponse:
         )
         return RawResponse(
             response,
-            lambda r: DocumentType.model_validate(r.json()),
+            lambda r: DocumentType.model_validate(r.json().get("data", r.json())),
         )
 
     def validate(
@@ -842,6 +842,7 @@ class DocumentTypesWithRawResponse:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> RawResponse[DocumentType]:
         """Create a document type and return the raw HTTP response.
 
@@ -855,6 +856,7 @@ class DocumentTypesWithRawResponse:
             identify_prompt_hints: Hints for document identification prompt.
             conversion_mode: Processing mode.
             keep_property_ordering: Preserve property ordering in schema.
+            is_public: Whether the document type is publicly available.
 
         Returns:
             RawResponse wrapping the HTTP response.
@@ -877,6 +879,8 @@ class DocumentTypesWithRawResponse:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = self._document_types._client._request(
             "POST", "/api/document-types", json=body
@@ -898,6 +902,7 @@ class DocumentTypesWithRawResponse:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> RawResponse[DocumentType]:
         """Update a document type and return the raw HTTP response.
 
@@ -911,6 +916,7 @@ class DocumentTypesWithRawResponse:
             identify_prompt_hints: New identification prompt hints.
             conversion_mode: New processing mode.
             keep_property_ordering: New property ordering setting.
+            is_public: New public/private flag.
 
         Returns:
             RawResponse wrapping the HTTP response.
@@ -934,6 +940,8 @@ class DocumentTypesWithRawResponse:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = self._document_types._client._request(
             "PUT",
@@ -1020,7 +1028,7 @@ class AsyncDocumentTypesWithRawResponse:
         )
         return RawResponse(
             response,
-            lambda r: DocumentType.model_validate(r.json()),
+            lambda r: DocumentType.model_validate(r.json().get("data", r.json())),
         )
 
     async def validate(
@@ -1061,6 +1069,7 @@ class AsyncDocumentTypesWithRawResponse:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> RawResponse[DocumentType]:
         """Create a document type and return the raw HTTP response.
 
@@ -1074,6 +1083,7 @@ class AsyncDocumentTypesWithRawResponse:
             identify_prompt_hints: Hints for document identification prompt.
             conversion_mode: Processing mode.
             keep_property_ordering: Preserve property ordering in schema.
+            is_public: Whether the document type is publicly available.
 
         Returns:
             RawResponse wrapping the HTTP response.
@@ -1096,6 +1106,8 @@ class AsyncDocumentTypesWithRawResponse:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = await self._document_types._client._request(
             "POST", "/api/document-types", json=body
@@ -1117,6 +1129,7 @@ class AsyncDocumentTypesWithRawResponse:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> RawResponse[DocumentType]:
         """Update a document type and return the raw HTTP response.
 
@@ -1130,6 +1143,7 @@ class AsyncDocumentTypesWithRawResponse:
             identify_prompt_hints: New identification prompt hints.
             conversion_mode: New processing mode.
             keep_property_ordering: New property ordering setting.
+            is_public: New public/private flag.
 
         Returns:
             RawResponse wrapping the HTTP response.
@@ -1153,6 +1167,8 @@ class AsyncDocumentTypesWithRawResponse:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = await self._document_types._client._request(
             "PUT",

--- a/src/docutray/_version.py
+++ b/src/docutray/_version.py
@@ -1,3 +1,3 @@
 """Version information for the DocuTray SDK."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/docutray/resources/document_types.py
+++ b/src/docutray/resources/document_types.py
@@ -121,10 +121,10 @@ class DocumentTypes:
         Example:
             >>> doc_type = client.document_types.get("dt_abc123")
             >>> print(f"Name: {doc_type.name}")
-            >>> print(f"Schema: {doc_type.schema_}")
+            >>> print(f"Schema: {doc_type.jsonSchema}")
         """
         response = self._client._request("GET", f"/api/document-types/{type_id}")
-        return DocumentType.model_validate(response.json())
+        return DocumentType.model_validate(response.json().get("data", response.json()))
 
     def validate(
         self,
@@ -173,6 +173,7 @@ class DocumentTypes:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> DocumentType:
         """Create a new document type.
 
@@ -186,6 +187,7 @@ class DocumentTypes:
             identify_prompt_hints: Hints for document identification prompt.
             conversion_mode: Processing mode ("json", "toon", or "multi_prompt").
             keep_property_ordering: Preserve property ordering in schema.
+            is_public: Whether the document type is publicly available.
 
         Returns:
             The created document type.
@@ -224,6 +226,8 @@ class DocumentTypes:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = self._client._request("POST", "/api/document-types", json=body)
         return DocumentType.model_validate(response.json().get("data", response.json()))
@@ -240,6 +244,7 @@ class DocumentTypes:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> DocumentType:
         """Update an existing document type.
 
@@ -255,6 +260,7 @@ class DocumentTypes:
             identify_prompt_hints: New identification prompt hints.
             conversion_mode: New processing mode.
             keep_property_ordering: New property ordering setting.
+            is_public: New public/private flag.
 
         Returns:
             The updated document type.
@@ -288,6 +294,8 @@ class DocumentTypes:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = self._client._request(
             "PUT",
@@ -397,7 +405,7 @@ class AsyncDocumentTypes:
             The document type details including schema.
         """
         response = await self._client._request("GET", f"/api/document-types/{type_id}")
-        return DocumentType.model_validate(response.json())
+        return DocumentType.model_validate(response.json().get("data", response.json()))
 
     async def validate(
         self,
@@ -432,6 +440,7 @@ class AsyncDocumentTypes:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> DocumentType:
         """Create a new document type.
 
@@ -445,6 +454,7 @@ class AsyncDocumentTypes:
             identify_prompt_hints: Hints for document identification prompt.
             conversion_mode: Processing mode ("json", "toon", or "multi_prompt").
             keep_property_ordering: Preserve property ordering in schema.
+            is_public: Whether the document type is publicly available.
 
         Returns:
             The created document type.
@@ -465,6 +475,8 @@ class AsyncDocumentTypes:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = await self._client._request("POST", "/api/document-types", json=body)
         return DocumentType.model_validate(response.json().get("data", response.json()))
@@ -481,6 +493,7 @@ class AsyncDocumentTypes:
         identify_prompt_hints: str | None = None,
         conversion_mode: ConversionMode | None = None,
         keep_property_ordering: bool | None = None,
+        is_public: bool | None = None,
     ) -> DocumentType:
         """Update an existing document type.
 
@@ -496,6 +509,7 @@ class AsyncDocumentTypes:
             identify_prompt_hints: New identification prompt hints.
             conversion_mode: New processing mode.
             keep_property_ordering: New property ordering setting.
+            is_public: New public/private flag.
 
         Returns:
             The updated document type.
@@ -517,6 +531,8 @@ class AsyncDocumentTypes:
             body["conversionMode"] = conversion_mode
         if keep_property_ordering is not None:
             body["keepPropertyOrdering"] = keep_property_ordering
+        if is_public is not None:
+            body["isPublic"] = is_public
 
         response = await self._client._request(
             "PUT",

--- a/src/docutray/types/document_type.py
+++ b/src/docutray/types/document_type.py
@@ -43,8 +43,8 @@ class DocumentType(BaseModel):
     updatedAt: datetime | None = None
     """Last update timestamp."""
 
-    schema_: dict[str, Any] | None = None
-    """JSON schema for the document type (when retrieved by ID)."""
+    jsonSchema: dict[str, Any] | None = None
+    """JSON Schema for the document type (returned by GET /api/document-types/{id})."""
 
 
 class ValidationErrorInfo(BaseModel):

--- a/tests/test_resources/test_document_types.py
+++ b/tests/test_resources/test_document_types.py
@@ -11,7 +11,9 @@ from docutray import AsyncClient, Client, DocumentType, ValidationResult
 class TestDocumentTypesList:
     """Tests for DocumentTypes.list()."""
 
-    def test_list_document_types(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_list_document_types(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """List all document types."""
         mock_api.get("/api/document-types").mock(
             return_value=httpx.Response(
@@ -52,13 +54,17 @@ class TestDocumentTypesList:
         assert response.total == 2
         assert response.page == 1
 
-    def test_list_with_pagination(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_list_with_pagination(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """List document types with pagination parameters."""
         mock_api.get("/api/document-types").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "data": [{"id": "dt_3", "name": "Contract", "codeType": "contract"}],
+                    "data": [
+                        {"id": "dt_3", "name": "Contract", "codeType": "contract"}
+                    ],
                     "pagination": {"total": 15, "page": 2, "limit": 5},
                 },
             )
@@ -91,19 +97,27 @@ class TestDocumentTypesList:
 class TestDocumentTypesGet:
     """Tests for DocumentTypes.get()."""
 
-    def test_get_document_type(self, client: Client, mock_api: respx.MockRouter) -> None:
-        """Get a specific document type."""
+    def test_get_document_type(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
+        """Get a specific document type unwraps the {data} envelope."""
         mock_api.get("/api/document-types/dt_123").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "id": "dt_123",
-                    "name": "Invoice",
-                    "codeType": "invoice",
-                    "description": "Invoice documents with line items",
-                    "isPublic": True,
-                    "isDraft": False,
-                    "createdAt": "2024-01-01T00:00:00.000Z",
+                    "data": {
+                        "id": "dt_123",
+                        "name": "Invoice",
+                        "codeType": "invoice",
+                        "description": "Invoice documents with line items",
+                        "isPublic": True,
+                        "isDraft": False,
+                        "createdAt": "2024-01-01T00:00:00.000Z",
+                        "jsonSchema": {
+                            "type": "object",
+                            "properties": {"invoice_number": {"type": "string"}},
+                        },
+                    }
                 },
             )
         )
@@ -114,12 +128,18 @@ class TestDocumentTypesGet:
         assert doc_type.id == "dt_123"
         assert doc_type.name == "Invoice"
         assert doc_type.codeType == "invoice"
+        assert doc_type.jsonSchema == {
+            "type": "object",
+            "properties": {"invoice_number": {"type": "string"}},
+        }
 
 
 class TestDocumentTypesValidate:
     """Tests for DocumentTypes.validate()."""
 
-    def test_validate_valid_data(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_validate_valid_data(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """Validate data that passes validation."""
         mock_api.post("/api/document-types/dt_123/validate").mock(
             return_value=httpx.Response(
@@ -140,7 +160,9 @@ class TestDocumentTypesValidate:
         assert result.is_valid()
         assert not result.has_warnings()
 
-    def test_validate_invalid_data(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_validate_invalid_data(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """Validate data that fails validation."""
         mock_api.post("/api/document-types/dt_123/validate").mock(
             return_value=httpx.Response(
@@ -164,7 +186,9 @@ class TestDocumentTypesValidate:
         assert result.errors.count == 2
         assert "invoice_number" in result.errors.messages[0]
 
-    def test_validate_with_warnings(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_validate_with_warnings(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """Validate data that has warnings but passes."""
         mock_api.post("/api/document-types/dt_123/validate").mock(
             return_value=httpx.Response(
@@ -189,7 +213,9 @@ class TestDocumentTypesValidate:
 class TestDocumentTypesCreate:
     """Tests for DocumentTypes.create()."""
 
-    def test_create_document_type(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_create_document_type(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """Create a document type with required fields."""
         route = mock_api.post("/api/document-types").mock(
             return_value=httpx.Response(
@@ -281,11 +307,78 @@ class TestDocumentTypesCreate:
         assert body["conversionMode"] == "multi_prompt"
         assert body["keepPropertyOrdering"] is True
 
+    def test_create_forwards_is_public(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
+        """Create forwards is_public to the request body as isPublic."""
+        route = mock_api.post("/api/document-types").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "data": {
+                        "id": "dt_pub",
+                        "name": "Receipt",
+                        "codeType": "receipt",
+                        "description": "Public receipt type",
+                        "isPublic": True,
+                        "isDraft": False,
+                    }
+                },
+            )
+        )
+
+        client.document_types.create(
+            name="Receipt",
+            code_type="receipt",
+            description="Public receipt type",
+            json_schema={"type": "object"},
+            is_public=True,
+        )
+
+        import json
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["isPublic"] is True
+
+    def test_create_omits_is_public_when_none(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
+        """Create does not include isPublic in body when is_public is None."""
+        route = mock_api.post("/api/document-types").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "data": {
+                        "id": "dt_x",
+                        "name": "X",
+                        "codeType": "x",
+                        "description": "X",
+                        "isPublic": False,
+                        "isDraft": True,
+                    }
+                },
+            )
+        )
+
+        client.document_types.create(
+            name="X",
+            code_type="x",
+            description="X",
+            json_schema={"type": "object"},
+        )
+
+        import json
+
+        body = json.loads(route.calls[0].request.content)
+        assert "isPublic" not in body
+
 
 class TestDocumentTypesUpdate:
     """Tests for DocumentTypes.update()."""
 
-    def test_update_document_type(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_update_document_type(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """Update a document type with partial fields."""
         route = mock_api.put("/api/document-types/dt_123").mock(
             return_value=httpx.Response(
@@ -323,7 +416,9 @@ class TestDocumentTypesUpdate:
         body = json.loads(route.calls[0].request.content)
         assert body == {"name": "Updated Invoice", "isDraft": False}
 
-    def test_update_json_schema(self, client: Client, mock_api: respx.MockRouter) -> None:
+    def test_update_json_schema(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
         """Update a document type's JSON schema."""
         mock_api.put("/api/document-types/dt_123").mock(
             return_value=httpx.Response(
@@ -352,6 +447,33 @@ class TestDocumentTypesUpdate:
         doc_type = client.document_types.update("dt_123", json_schema=new_schema)
 
         assert doc_type.id == "dt_123"
+
+    def test_update_forwards_is_public(
+        self, client: Client, mock_api: respx.MockRouter
+    ) -> None:
+        """Update forwards is_public to the request body as isPublic."""
+        route = mock_api.put("/api/document-types/dt_123").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "id": "dt_123",
+                        "name": "Invoice",
+                        "codeType": "invoice",
+                        "description": "Invoice documents",
+                        "isPublic": False,
+                        "isDraft": False,
+                    }
+                },
+            )
+        )
+
+        client.document_types.update("dt_123", is_public=False)
+
+        import json
+
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"isPublic": False}
 
 
 class TestDocumentTypeModel:
@@ -424,7 +546,9 @@ class TestAsyncDocumentTypesList:
             return_value=httpx.Response(
                 200,
                 json={
-                    "data": [{"id": "dt_3", "name": "Contract", "codeType": "contract"}],
+                    "data": [
+                        {"id": "dt_3", "name": "Contract", "codeType": "contract"}
+                    ],
                     "pagination": {"total": 15, "page": 2, "limit": 5},
                 },
             )
@@ -442,18 +566,21 @@ class TestAsyncDocumentTypesGet:
     async def test_async_get_document_type(
         self, async_client: AsyncClient, mock_api: respx.MockRouter
     ) -> None:
-        """Async get a specific document type."""
+        """Async get a specific document type unwraps the {data} envelope."""
         mock_api.get("/api/document-types/dt_123").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "id": "dt_123",
-                    "name": "Invoice",
-                    "codeType": "invoice",
-                    "description": "Invoice documents with line items",
-                    "isPublic": True,
-                    "isDraft": False,
-                    "createdAt": "2024-01-01T00:00:00.000Z",
+                    "data": {
+                        "id": "dt_123",
+                        "name": "Invoice",
+                        "codeType": "invoice",
+                        "description": "Invoice documents with line items",
+                        "isPublic": True,
+                        "isDraft": False,
+                        "createdAt": "2024-01-01T00:00:00.000Z",
+                        "jsonSchema": {"type": "object"},
+                    }
                 },
             )
         )
@@ -464,6 +591,7 @@ class TestAsyncDocumentTypesGet:
         assert doc_type.id == "dt_123"
         assert doc_type.name == "Invoice"
         assert doc_type.codeType == "invoice"
+        assert doc_type.jsonSchema == {"type": "object"}
 
 
 class TestAsyncDocumentTypesValidate:

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,7 @@ toml = [
 
 [[package]]
 name = "docutray"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #19

## Summary

Ports [docutray-node#20](https://github.com/docutray/docutray-node/pull/20) to the Python SDK and closes a small gap from the [docutray-node#18](https://github.com/docutray/docutray-node/pull/18) port (missing `is_public` kwarg).

### Bug fix — `document_types.get()` returns the raw `{data}` wrapper

`GET /api/document-types/{id}` returns `{ "data": {...} }`, same as `POST` / `PUT`. With `model_config = ConfigDict(extra="allow")` on `DocumentType`, `model_validate({"data": {...}})` did not raise — but every typed field (`id`, `name`, `codeType`, …) silently fell back to defaults because the actual fields were nested under `data`. Consumers received a `DocumentType` whose fields all looked empty.

Fixed sync (`document_types.py:127`), async (`document_types.py:402`), and the raw response wrappers (`_response.py:803, 1023`) by mirroring the unwrap pattern already used by `create()` / `update()`:

```python
return DocumentType.model_validate(
    response.json().get("data", response.json())
)
```

### Type-only breaking change — `DocumentType.schema_` → `DocumentType.jsonSchema`

The API returns this field as `jsonSchema` (consistent with `codeType`, `isDraft`, `createdAt`). The previous name `schema_` never matched the wire — the field was always `None`. Renamed to match the API. Pre-1.0 patch releases are allowed to carry type-level breaking changes per project policy. Updated the docstring example in `resources/document_types.py:124` and the README example.

### Gap closed — `is_public` kwarg on create/update

The Node `DocumentTypeCreateParams` / `DocumentTypeUpdateParams` interfaces both expose `isPublic`. Added `is_public: bool | None = None` kwarg to all six methods (sync, async, and raw response wrappers for both `create()` and `update()`).

## Acceptance criteria

- [x] `client.document_types.get(id)` returns a flat `DocumentType` with all fields populated (sync + async + raw wrappers).
- [x] `DocumentType.jsonSchema` replaces `DocumentType.schema_`. Docstring + README example updated.
- [x] `client.document_types.create(...)` and `.update(...)` accept `is_public: bool | None = None` (six methods total).
- [x] Tests cover `get()` mocked with `{"data": {...}}` and assert unwrapped result including `jsonSchema`. Tests cover `is_public=True` / `is_public=False` forwarding to body as `isPublic`, and `is_public=None` omits the field.
- [x] `uv run pytest` (340 passed), `uv run mypy src` (clean), `uv run ruff check src tests` (clean).
- [x] CHANGELOG `[0.2.1]` entry; version bumped in `pyproject.toml` and `src/docutray/_version.py`.

## Out of scope

The Node PR #20 description flags an audit of other endpoints that may also be missing the `{data}` unwrap. In Python, `KnowledgeBases.get` and `KnowledgeBaseDocuments.get` already unwrap correctly. Status-polling endpoints (`Steps.get_status`, `Convert.*`, `Identify.*`) most likely are NOT wrapped, but should be confirmed in a separate issue.

## Test plan

- [x] Unit: `tests/test_resources/test_document_types.py` — `get()` mocks `{"data": {...}}`, asserts `doc_type.jsonSchema` populated; new tests for `is_public` forwarding (sync create + update; existing async tests still pass against unchanged surface).
- [x] Full suite: 340/340 passing.
- [ ] Smoke test against real backend once published — verify `client.document_types.get()` no longer returns empty fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)